### PR TITLE
Added autoselect support between "docker compose" and "docker-compose"

### DIFF
--- a/templates/ever-node/start_node.sh
+++ b/templates/ever-node/start_node.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+
+dc=""
+
+docker-compose version >/dev/null 2>/dev/null
+if [[ "$?" == "0" ]]; then
+    dc="docker-compose"
+fi
+
+docker compose version >/dev/null 2>/dev/null
+if [[ "$?" == "0" ]]; then
+    dc="docker compose"
+fi
+
+if [[ "$dc" == "" ]]; then
+    echo "Error: functioning docker compose or docker-compose not found"
+    exit 1
+fi
+
 cd deploy/ever-node
 rm -rf build/ever-node
 cd build && git clone --recursive {{EVERNODE_GITHUB_REPO}} ever-node
@@ -12,14 +30,14 @@ cd ../../
 echo "==============================================================================="
 echo "INFO: starting node on {{HOSTNAME}}..."
 
-docker-compose up --build -d
+$dc up --build -d
 docker exec --tty ever-node "/ever-node/scripts/generate_console_config.sh"
 
-docker-compose down -t 300
+$dc down -t 300
 sed -i 's/"client_enabled":.*/"client_enabled": true,/' configs/config.json
 sed -i 's/"service_enabled":.*/"service_enabled": true,/' configs/config.json
 sed -i 's/command: \["bash"\]/command: ["normal"]/' docker-compose.yml
-docker-compose up -d
+$dc up -d
 echo "INFO: starting node on {{HOSTNAME}}... DONE"
 echo "==============================================================================="
 

--- a/up.sh
+++ b/up.sh
@@ -1,22 +1,39 @@
 #!/bin/bash
 
+dc=""
+
+docker-compose version >/dev/null 2>/dev/null
+if [[ "$?" == "0" ]]; then
+    dc="docker-compose"
+fi
+
+docker compose version >/dev/null 2>/dev/null
+if [[ "$?" == "0" ]]; then
+    dc="docker compose"
+fi
+
+if [[ "$dc" == "" ]]; then
+    echo "Error: functioning docker compose or docker-compose not found"
+    exit 1
+fi
+
 echo "Starting Statsd"
-docker-compose -f deploy/statsd/docker-compose.yml up --build -d
+$dc -f deploy/statsd/docker-compose.yml up --build -d
 
 echo "Starting ArangoDB"
-docker-compose -f deploy/arangodb/docker-compose.yml up --build -d
+$dc -f deploy/arangodb/docker-compose.yml up --build -d
 
 
 echo "Starting Kafka & Kafka Connect"
-docker-compose -f deploy/kafka/docker-compose.yml up --build -d
+$dc -f deploy/kafka/docker-compose.yml up --build -d
 
 
 echo "Starting Q-Server"
-docker-compose -f deploy/q-server/docker-compose.yml up --build -d
+$dc -f deploy/q-server/docker-compose.yml up --build -d
 
 
 echo "Starting Node"
 ./deploy/ever-node/start_node.sh 
 
 echo "Starting reverse proxy"
-docker-compose -f deploy/proxy/docker-compose.yml up --build -d
+$dc -f deploy/proxy/docker-compose.yml up --build -d


### PR DESCRIPTION
Deployment scripts had an issue that they do not properly work on newer docker installations, that have compose installed as a plugin instead of separate python application.

This commit fixes that, by testing for `docker compose version` and `docker-compose version` and automatically deciding which version to use accordingly.

Additionally, a proper error message is displayed if there is no any usable docker compose tool.

In case both utilities are present, priority is given to newer `docker compose` plugin.